### PR TITLE
Add project roadmap to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
 # TradeFlex
+
+TradeFlex is a platform designed for individual traders who want to build, test, and eventually deploy algorithmic trading strategies. This repository outlines the initial goals, design considerations, and development roadmap.
+
+## Project Goals
+
+- **Algorithm Interface**: Provide an easily extendable interface so algorithms can be swapped in and out without touching the core infrastructure. Each algorithm should implement standardized entry, exit, and risk management hooks.
+- **Backtest Framework**: Integrate with a backtesting engine that can replay historical market data and execute algorithms to validate performance.
+- **Manual Testing**: Offer a sandbox where a simple algorithm can be manually run to ensure it interacts with the backtester correctly before moving forward.
+- **Unit Tests**: Build a suite of tests verifying the behavior of algorithms and the backtest harness.
+- **Shadow Trading**: Design a system that mirrors real orders without executing them, showing what would have happened in a real environment.
+- **Live Trading Deployment**: Provide the ability to connect to a real broker so algorithms can trade with actual capital once validated.
+
+## Running the Project (Initial Guidance)
+
+The codebase currently contains only documentation, but it is intended to be Python-based. A typical setup would look like:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt  # placeholder, to be defined
+```
+
+Backtests and algorithms would live under a `tradeflex` package. Example usage might be:
+
+```bash
+python -m tradeflex.backtest --algorithm examples/simple_algo.py --data data/historical.csv
+```
+
+## Development Roadmap
+
+1. **Generate a Comprehensive Algorithm Interface**
+   - Define a base class with methods such as `on_tick`, `on_order_filled`, and `on_exit`.
+   - Allow runtime discovery of algorithms via an `algorithms` directory so new strategies can be swapped in easily.
+
+2. **Integrate with a Backtest Framework**
+   - Choose an engine (e.g., `backtrader`, `zipline`, or a minimal custom module) that can feed historical data into algorithms.
+   - Ensure the interface is generic enough to plug in future data sources.
+
+3. **Manually Test Simple Algorithm with the Backtester**
+   - Create a trivial algorithm (e.g., moving average crossover).
+   - Execute it against sample historical data, verifying trade signals and order handling.
+
+4. **Add Unit Tests**
+   - Use `pytest` to test algorithm logic and the backtest process.
+   - Include tests for edge cases such as empty data sets and erroneous algorithm behavior.
+
+5. **Shadow Trading Design**
+   - Implement a mode that publishes trade signals but logs them instead of executing, storing results side-by-side with real account data for comparison.
+   - Confirm this mode uses the same decision path as live trading so it is representative.
+
+6. **Enable Live Trading**
+   - Add broker integration (e.g., via REST or an SDK) for actual order placement.
+   - Include secure storage of API keys and risk checks to limit position sizing.
+
+7. **Iterate and Expand**
+   - Document new algorithms.
+   - Add performance dashboards and metrics.
+   - Improve the backtest environment with additional data sources and risk analysis tools.
+
+This project is in an early state. Follow the roadmap above to incrementally build out the full functionality.


### PR DESCRIPTION
## Summary
- flesh out README with project goals and roadmap for algorithmic trading platform

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684379d0b238833382cebcaf89c5cda5