### PR TITLE
Add ITradingAlgorithm interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ dotnet run --project TradeFlex.Backtest --algo Examples/SimpleAlgo.cs --data dat
 ## Development Roadmap
 
 1. **Generate a Comprehensive Algorithm Interface**
-   - Define a base class with methods such as `on_tick`, `on_order_filled`, and `on_exit`.
+   - Define `ITradingAlgorithm` with hooks such as `OnBar`, `OnEntry`, `OnExit`, and `OnRiskCheck`.
    - Allow runtime discovery of algorithms via an `algorithms` directory so new strategies can be swapped in easily.
 
 ### Example Algorithm Interface
@@ -39,23 +39,16 @@ Below is a minimal C# implementation of the interface described above. It uses
 abstract and virtual methods so each strategy can override the necessary hooks:
 
 ```csharp
-namespace TradeFlex.Core;
+namespace TradeFlex.Abstractions;
 
-public abstract class BaseAlgorithm
+public interface ITradingAlgorithm
 {
-    /// <summary>Called once before any ticks are processed.</summary>
-    public virtual void OnStart(IContext context) {}
-
-    /// <summary>Handle a new market tick.</summary>
-    public abstract void OnTick(Tick tick);
-
-    /// <summary>React to an order fill event.</summary>
-    public abstract void OnOrderFilled(Order order);
-
-    /// <summary>Clean up resources before shutdown.</summary>
-    public abstract void OnExit();
+    void Initialize();
+    void OnBar(Bar bar);
+    void OnEntry(Order order);
+    void OnExit();
+    bool OnRiskCheck(Order order);
 }
-
 ```
 
 Algorithms implementing this interface should live under an `algorithms/`

--- a/TradeFlex.Abstractions/ITradingAlgorithm.cs
+++ b/TradeFlex.Abstractions/ITradingAlgorithm.cs
@@ -1,0 +1,55 @@
+namespace TradeFlex.Abstractions;
+
+/// <summary>
+/// Exposes the primary hooks required for a trading algorithm.
+/// </summary>
+public interface ITradingAlgorithm
+{
+    /// <summary>
+    /// Called once before any bars are processed.
+    /// </summary>
+    void Initialize();
+
+    /// <summary>
+    /// Invoked for each incoming bar of market data.
+    /// </summary>
+    /// <param name="bar">The latest bar.</param>
+    void OnBar(Bar bar);
+
+    /// <summary>
+    /// Called when an entry order is created.
+    /// </summary>
+    /// <param name="order">The order used to enter a position.</param>
+    void OnEntry(Order order);
+
+    /// <summary>
+    /// Called when the algorithm shuts down or exits a position.
+    /// </summary>
+    void OnExit();
+
+    /// <summary>
+    /// Performs a risk check before an order is submitted.
+    /// </summary>
+    /// <param name="order">The order to validate.</param>
+    /// <returns>True if the order passes risk controls; otherwise, false.</returns>
+    bool OnRiskCheck(Order order);
+}
+
+/// <summary>
+/// Represents a single bar of market data.
+/// </summary>
+/// <param name="Timestamp">The time of the bar.</param>
+/// <param name="Open">The opening price.</param>
+/// <param name="High">The highest price.</param>
+/// <param name="Low">The lowest price.</param>
+/// <param name="Close">The closing price.</param>
+/// <param name="Volume">The traded volume.</param>
+public record Bar(DateTime Timestamp, decimal Open, decimal High, decimal Low, decimal Close, long Volume);
+
+/// <summary>
+/// Represents an order to buy or sell a security.
+/// </summary>
+/// <param name="Symbol">The instrument symbol.</param>
+/// <param name="Quantity">The quantity to trade.</param>
+/// <param name="Price">The price of the order.</param>
+public record Order(string Symbol, int Quantity, decimal Price);

--- a/TradeFlex.Abstractions/TradeFlex.Abstractions.csproj
+++ b/TradeFlex.Abstractions/TradeFlex.Abstractions.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/TradeFlex.Core/BaseAlgorithm.cs
+++ b/TradeFlex.Core/BaseAlgorithm.cs
@@ -1,13 +1,24 @@
+using TradeFlex.Abstractions;
+
 namespace TradeFlex.Core;
 
-public abstract class BaseAlgorithm
+/// <summary>
+/// Base class implementing <see cref="ITradingAlgorithm"/> with no-op defaults.
+/// </summary>
+public abstract class BaseAlgorithm : ITradingAlgorithm
 {
-    public virtual void OnStart(IContext context) { }
-    public abstract void OnTick(Tick tick);
-    public abstract void OnOrderFilled(Order order);
-    public abstract void OnExit();
-}
+    /// <inheritdoc />
+    public virtual void Initialize() { }
 
-public interface IContext { }
-public record Tick(decimal Price);
-public record Order(string Symbol, int Quantity, decimal Price);
+    /// <inheritdoc />
+    public abstract void OnBar(Bar bar);
+
+    /// <inheritdoc />
+    public abstract void OnEntry(Order order);
+
+    /// <inheritdoc />
+    public abstract void OnExit();
+
+    /// <inheritdoc />
+    public abstract bool OnRiskCheck(Order order);
+}

--- a/TradeFlex.Core/TradeFlex.Core.csproj
+++ b/TradeFlex.Core/TradeFlex.Core.csproj
@@ -4,4 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TradeFlex.Abstractions\TradeFlex.Abstractions.csproj" />
+  </ItemGroup>
 </Project>

--- a/TradeFlex.sln
+++ b/TradeFlex.sln
@@ -1,20 +1,25 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TradeFlex.Core", "TradeFlex.Core/TradeFlex.Core.csproj", "{D4C31F21-9647-4C12-AE31-CECC495EEDFA}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TradeFlex.Core", "TradeFlex.Core\TradeFlex.Core.csproj", "{D4C31F21-9647-4C12-AE31-CECC495EEDFA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TradeFlex.Abstractions", "TradeFlex.Abstractions\TradeFlex.Abstractions.csproj", "{FC90120B-6497-4229-A521-E977F973A404}"
 EndProject
 Global
-GlobalSection(SolutionConfigurationPlatforms) = preSolution
-Debug|Any CPU = Debug|Any CPU
-Release|Any CPU = Release|Any CPU
-EndGlobalSection
-GlobalSection(ProjectConfigurationPlatforms) = postSolution
-{D4C31F21-9647-4C12-AE31-CECC495EEDFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-{D4C31F21-9647-4C12-AE31-CECC495EEDFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-{D4C31F21-9647-4C12-AE31-CECC495EEDFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-{D4C31F21-9647-4C12-AE31-CECC495EEDFA}.Release|Any CPU.Build.0 = Release|Any CPU
-EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D4C31F21-9647-4C12-AE31-CECC495EEDFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4C31F21-9647-4C12-AE31-CECC495EEDFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4C31F21-9647-4C12-AE31-CECC495EEDFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4C31F21-9647-4C12-AE31-CECC495EEDFA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC90120B-6497-4229-A521-E977F973A404}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC90120B-6497-4229-A521-E977F973A404}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC90120B-6497-4229-A521-E977F973A404}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC90120B-6497-4229-A521-E977F973A404}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
 EndGlobal
-


### PR DESCRIPTION
## Summary
- introduce **TradeFlex.Abstractions** project
- define `ITradingAlgorithm` with XML docs
- update `BaseAlgorithm` to implement the interface
- add project reference from core to abstractions
- update README example

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6843832c91088333a236142e0d47cf67