### PR TITLE
Add trading abstractions and dummy algorithm test

### DIFF
--- a/TradeFlex.Abstractions/ITradingAlgorithm.cs
+++ b/TradeFlex.Abstractions/ITradingAlgorithm.cs
@@ -53,3 +53,28 @@ public record Bar(DateTime Timestamp, decimal Open, decimal High, decimal Low, d
 /// <param name="Quantity">The quantity to trade.</param>
 /// <param name="Price">The price of the order.</param>
 public record Order(string Symbol, int Quantity, decimal Price);
+
+/// <summary>
+/// Direction for an order or trade.
+/// </summary>
+public enum OrderSide
+{
+    /// <summary>
+    /// A buy order.
+    /// </summary>
+    Buy,
+
+    /// <summary>
+    /// A sell order.
+    /// </summary>
+    Sell
+}
+
+/// <summary>
+/// Represents an executed trade.
+/// </summary>
+/// <param name="Symbol">The traded instrument.</param>
+/// <param name="Quantity">The number of shares or contracts.</param>
+/// <param name="Price">The execution price.</param>
+/// <param name="Side">Whether the trade was a buy or sell.</param>
+public record Trade(string Symbol, int Quantity, decimal Price, OrderSide Side);

--- a/TradeFlex.Tests/DummyAlgorithmTests.cs
+++ b/TradeFlex.Tests/DummyAlgorithmTests.cs
@@ -1,0 +1,26 @@
+using TradeFlex.Abstractions;
+
+namespace TradeFlex.Tests;
+
+public class DummyAlgorithmTests
+{
+    private sealed class DummyAlgorithm : ITradingAlgorithm
+    {
+        public void Initialize() { }
+
+        public void OnBar(Bar bar) { }
+
+        public void OnEntry(Order order) { }
+
+        public void OnExit() { }
+
+        public bool OnRiskCheck(Order order) => true;
+    }
+
+    [Fact]
+    public void DummyAlgorithmLoads()
+    {
+        ITradingAlgorithm algo = new DummyAlgorithm();
+        Assert.NotNull(algo);
+    }
+}

--- a/TradeFlex.Tests/TradeFlex.Tests.csproj
+++ b/TradeFlex.Tests/TradeFlex.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TradeFlex.Abstractions\TradeFlex.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/TradeFlex.sln
+++ b/TradeFlex.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TradeFlex.Core", "TradeFlex
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TradeFlex.Abstractions", "TradeFlex.Abstractions\TradeFlex.Abstractions.csproj", "{FC90120B-6497-4229-A521-E977F973A404}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TradeFlex.Tests", "TradeFlex.Tests\TradeFlex.Tests.csproj", "{740FD459-EB83-4542-820D-7437F358FF65}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,5 +23,9 @@ Global
 		{FC90120B-6497-4229-A521-E977F973A404}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC90120B-6497-4229-A521-E977F973A404}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FC90120B-6497-4229-A521-E977F973A404}.Release|Any CPU.Build.0 = Release|Any CPU
+		{740FD459-EB83-4542-820D-7437F358FF65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{740FD459-EB83-4542-820D-7437F358FF65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{740FD459-EB83-4542-820D-7437F358FF65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{740FD459-EB83-4542-820D-7437F358FF65}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- extend `ITradingAlgorithm` with `OrderSide` enum and `Trade` record
- add unit test project with dummy algorithm ensuring the interface loads

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684386320a8c83338cd6bd06446079b6