### PR TITLE
Add SimulationClock for deterministic time

### DIFF
--- a/TradeFlex.Core/SimulationClock.cs
+++ b/TradeFlex.Core/SimulationClock.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace TradeFlex.Core;
+
+/// <summary>
+/// Provides deterministic time progression for simulations and tests.
+/// </summary>
+public sealed class SimulationClock
+{
+    private readonly TimeSpan _step;
+    private DateTime _current;
+
+    /// <summary>
+    /// Initializes the clock at a specific start time and step increment.
+    /// </summary>
+    /// <param name="start">The first timestamp to return.</param>
+    /// <param name="step">How much time passes on each <see cref="Advance"/> call.</param>
+    public SimulationClock(DateTime start, TimeSpan step)
+    {
+        _current = start;
+        _step = step;
+    }
+
+    /// <summary>
+    /// Gets the current simulated time.
+    /// </summary>
+    public DateTime UtcNow => _current;
+
+    /// <summary>
+    /// Advances time by the configured step and returns the new value.
+    /// </summary>
+    /// <returns>The advanced timestamp.</returns>
+    public DateTime Advance()
+    {
+        _current = _current.Add(_step);
+        return _current;
+    }
+}
+

--- a/TradeFlex.Tests/SimulationClockTests.cs
+++ b/TradeFlex.Tests/SimulationClockTests.cs
@@ -1,0 +1,23 @@
+using TradeFlex.Core;
+
+namespace TradeFlex.Tests;
+
+public class SimulationClockTests
+{
+    [Fact]
+    public void IdenticalRunsYieldIdenticalTimestamps()
+    {
+        var start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var step = TimeSpan.FromMinutes(1);
+
+        var clock1 = new SimulationClock(start, step);
+        var clock2 = new SimulationClock(start, step);
+
+        for (int i = 0; i < 10; i++)
+        {
+            Assert.Equal(clock1.UtcNow, clock2.UtcNow);
+            clock1.Advance();
+            clock2.Advance();
+        }
+    }
+}

--- a/TradeFlex.Tests/TradeFlex.Tests.csproj
+++ b/TradeFlex.Tests/TradeFlex.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TradeFlex.Abstractions\TradeFlex.Abstractions.csproj" />
+    <ProjectReference Include="..\TradeFlex.Core\TradeFlex.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- implement `SimulationClock` in Core library
- test deterministic timestamp generation
- reference `TradeFlex.Core` in tests

## Testing
- `dotnet test --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_6843893ef6f08333bf24b7fce275d2c9