### PR TITLE
Fix Parquet loader tests without binary fixtures

### DIFF
--- a/TradeFlex.Backtest/ParquetBarDataLoader.cs
+++ b/TradeFlex.Backtest/ParquetBarDataLoader.cs
@@ -1,0 +1,58 @@
+using Parquet;
+using Parquet.Data;
+using System.Collections;
+using System.Linq;
+using TradeFlex.Abstractions;
+
+namespace TradeFlex.Backtest;
+
+/// <summary>
+/// Loads <see cref="Bar"/> records from minute-bar Parquet files.
+/// </summary>
+public static class ParquetBarDataLoader
+{
+    private static readonly string DataDirectory = Path.Combine(AppContext.BaseDirectory, "data");
+
+    /// <summary>
+    /// Asynchronously reads bars from a Parquet file under the data directory.
+    /// </summary>
+    /// <param name="fileName">The file name within the <c>/data</c> directory.</param>
+    /// <returns>An async enumerable of bars.</returns>
+    public static async IAsyncEnumerable<Bar> LoadAsync(string fileName)
+    {
+        var path = Path.Combine(DataDirectory, fileName);
+
+        using var stream = File.OpenRead(path);
+        using var reader = await ParquetReader.CreateAsync(stream);
+        var dataFields = reader.Schema.GetDataFields();
+
+        for (int g = 0; g < reader.RowGroupCount; g++)
+        {
+            using var groupReader = reader.OpenRowGroupReader(g);
+            var columns = new DataColumn[dataFields.Length];
+            for (int i = 0; i < dataFields.Length; i++)
+            {
+                columns[i] = await groupReader.ReadColumnAsync(dataFields[i]);
+            }
+
+            var timestamps = ((IEnumerable)columns[0].Data).Cast<object>()
+                .Select(v => v switch
+                {
+                    DateTime dt => DateTime.SpecifyKind(dt, DateTimeKind.Utc),
+                    DateTimeOffset dto => dto.UtcDateTime,
+                    _ => DateTime.Parse(v.ToString()!)
+                }).ToArray();
+            var opens = ((IEnumerable)columns[1].Data).Cast<object>().Select(v => Convert.ToDecimal(v)).ToArray();
+            var highs = ((IEnumerable)columns[2].Data).Cast<object>().Select(v => Convert.ToDecimal(v)).ToArray();
+            var lows = ((IEnumerable)columns[3].Data).Cast<object>().Select(v => Convert.ToDecimal(v)).ToArray();
+            var closes = ((IEnumerable)columns[4].Data).Cast<object>().Select(v => Convert.ToDecimal(v)).ToArray();
+            var volumes = ((IEnumerable)columns[5].Data).Cast<object>().Select(v => Convert.ToInt64(v)).ToArray();
+
+            for (int i = 0; i < timestamps.Length; i++)
+            {
+                yield return new Bar(timestamps[i], opens[i], highs[i], lows[i], closes[i], volumes[i]);
+            }
+        }
+    }
+}
+

--- a/TradeFlex.Backtest/TradeFlex.Backtest.csproj
+++ b/TradeFlex.Backtest/TradeFlex.Backtest.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Parquet.Net" Version="5.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TradeFlex.Abstractions\TradeFlex.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TradeFlex.Tests/ParquetBarDataLoaderTests.cs
+++ b/TradeFlex.Tests/ParquetBarDataLoaderTests.cs
@@ -1,0 +1,56 @@
+using Parquet;
+using Parquet.Data;
+using Parquet.Schema;
+using System.Linq;
+using TradeFlex.Backtest;
+using TradeFlex.Abstractions;
+
+namespace TradeFlex.Tests;
+
+public class ParquetBarDataLoaderTests
+{
+    [Fact]
+    public async Task LoadsBarsFromParquet()
+    {
+        var dataDir = Path.Combine(AppContext.BaseDirectory, "data");
+        Directory.CreateDirectory(dataDir);
+        var filePath = Path.Combine(dataDir, "minute_fixture.parquet");
+
+        var fixtureBars = new[]
+        {
+            new Bar(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), 1.0m, 1.1m, 0.9m, 1.05m, 1000),
+            new Bar(new DateTime(2024, 1, 1, 0, 1, 0, DateTimeKind.Utc), 1.05m, 1.15m, 1.0m, 1.1m, 1500),
+            new Bar(new DateTime(2024, 1, 1, 0, 2, 0, DateTimeKind.Utc), 1.1m, 1.2m, 1.05m, 1.15m, 1600)
+        };
+
+        var schema = new ParquetSchema(
+            new DataField<DateTime>("Timestamp"),
+            new DataField<decimal>("Open"),
+            new DataField<decimal>("High"),
+            new DataField<decimal>("Low"),
+            new DataField<decimal>("Close"),
+            new DataField<long>("Volume"));
+
+        await using (var fs = File.Create(filePath))
+        {
+            using var writer = await ParquetWriter.CreateAsync(schema, fs);
+            using var group = writer.CreateRowGroup();
+
+            await group.WriteColumnAsync(new DataColumn((DataField<DateTime>)schema[0], fixtureBars.Select(b => b.Timestamp).ToArray()));
+            await group.WriteColumnAsync(new DataColumn((DataField<decimal>)schema[1], fixtureBars.Select(b => b.Open).ToArray()));
+            await group.WriteColumnAsync(new DataColumn((DataField<decimal>)schema[2], fixtureBars.Select(b => b.High).ToArray()));
+            await group.WriteColumnAsync(new DataColumn((DataField<decimal>)schema[3], fixtureBars.Select(b => b.Low).ToArray()));
+            await group.WriteColumnAsync(new DataColumn((DataField<decimal>)schema[4], fixtureBars.Select(b => b.Close).ToArray()));
+            await group.WriteColumnAsync(new DataColumn((DataField<long>)schema[5], fixtureBars.Select(b => b.Volume).ToArray()));
+        }
+
+        var bars = new List<Bar>();
+        await foreach (var bar in ParquetBarDataLoader.LoadAsync("minute_fixture.parquet"))
+        {
+            bars.Add(bar);
+        }
+
+        Assert.Equal(3, bars.Count);
+        Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), bars[0].Timestamp);
+    }
+}

--- a/TradeFlex.Tests/TradeFlex.Tests.csproj
+++ b/TradeFlex.Tests/TradeFlex.Tests.csproj
@@ -12,13 +12,17 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Parquet.Net" Version="5.1.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\TradeFlex.Abstractions\TradeFlex.Abstractions.csproj" />
     <ProjectReference Include="..\TradeFlex.Core\TradeFlex.Core.csproj" />
     <ProjectReference Include="..\TradeFlex.SampleStrategies\TradeFlex.SampleStrategies.csproj" />
+    <ProjectReference Include="..\TradeFlex.Backtest\TradeFlex.Backtest.csproj" />
   </ItemGroup>
+
+
 
   <ItemGroup>
     <Using Include="Xunit" />

--- a/TradeFlex.sln
+++ b/TradeFlex.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TradeFlex.Tests", "TradeFle
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TradeFlex.SampleStrategies", "TradeFlex.SampleStrategies\TradeFlex.SampleStrategies.csproj", "{7BF11E7D-DE4C-4C1E-B2E3-96C47FAE8187}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TradeFlex.Backtest", "TradeFlex.Backtest\TradeFlex.Backtest.csproj", "{C89F45EF-440D-45EE-854F-739DC9A4C670}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,5 +35,9 @@ Global
 		{7BF11E7D-DE4C-4C1E-B2E3-96C47FAE8187}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7BF11E7D-DE4C-4C1E-B2E3-96C47FAE8187}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BF11E7D-DE4C-4C1E-B2E3-96C47FAE8187}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C89F45EF-440D-45EE-854F-739DC9A4C670}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C89F45EF-440D-45EE-854F-739DC9A4C670}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C89F45EF-440D-45EE-854F-739DC9A4C670}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C89F45EF-440D-45EE-854F-739DC9A4C670}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- remove binary Parquet fixture from repository
- add Parquet.Net to test project and generate fixture dynamically
- update unit test to write Parquet data at runtime

## Testing
- `dotnet test TradeFlex.sln`


------
https://chatgpt.com/codex/tasks/task_e_68438cc95c5c8333b8dcc006ea2504fc