### PR TITLE
Add README CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ dotnet new classlib -n TradeFlex.Core
 dotnet sln add TradeFlex.Core/TradeFlex.Core.csproj
 ```
 
-Backtests and algorithms will live under the `TradeFlex` namespace. Example usage might be:
+### Using the CLI
+
+Run commands through the `TradeFlex.Cli` project using `dotnet run`:
+
+```bash
+dotnet run --project TradeFlex.Cli -- [command] [options]
+```
+
+Example back-test:
 
 ```bash
 dotnet run --project TradeFlex.Cli -- backtest --algo path/to/Algo.dll --data path/to/minute.parquet --from 2024-01-01 --to 2024-01-02

--- a/TradeFlex.Cli/TradeFlex.Cli.csproj
+++ b/TradeFlex.Cli/TradeFlex.Cli.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary
- remove csproj comment for CLI usage
- document CLI usage in README

## Testing
- `dotnet test TradeFlex.Tests/TradeFlex.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_68439a7097d48333b9b84b3a15c15a5e